### PR TITLE
Removed complex command. Hardcode FQDN into config instead.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,8 @@ web:
   image: nginx:1.9.10
   container_name: rancher-web
   restart: always
-  command: sh -c "sed -e s/\$${RANCHER_FQDN}/$${RANCHER_FQDN}/g /nginx.conf.tpl > /etc/nginx/nginx.conf; exec nginx"
   volumes:
-    - ./nginx.conf.tpl:/nginx.conf.tpl:ro
+    - ./nginx.conf:/etc/nginx/nginx.conf:ro
     - /certs:/certs:ro
   links:
     - rancher

--- a/nginx.conf
+++ b/nginx.conf
@@ -5,7 +5,6 @@
 # https://wiki.mozilla.org/Security/Server_Side_TLS
 # https://cipherli.st/
 
-daemon off;
 user nginx nginx;
 worker_processes 2;
 
@@ -41,13 +40,13 @@ http {
 
   server {
     listen 80;
-    server_name ${RANCHER_FQDN};
-    return 301 https://${RANCHER_FQDN}$request_uri;
+    server_name rancher.weahead.se;
+    return 301 https://rancher.weahead.se$request_uri;
   }
 
   server {
     listen 443 ssl;
-    server_name ${RANCHER_FQDN};
+    server_name rancher.weahead.se;
 
     # SSL
     ssl on;


### PR DESCRIPTION
The hack to use environment variables in the nginx configuration was a complex thing to keep documented and maintained. So I removed it in favor of hard coded values.
